### PR TITLE
Tolerate NULL in information.place (geo_point) 

### DIFF
--- a/app-0-nodes/src/main/java/org.geovistory.toolbox.streams.nodes/processors/Nodes.java
+++ b/app-0-nodes/src/main/java/org.geovistory.toolbox.streams.nodes/processors/Nodes.java
@@ -135,10 +135,21 @@ public class Nodes {
 
         // Map places to nodes
         var placeNodes = infPlaceStream.map((key, value) -> {
+
+                    // if geoPoint is null (it can be considered as invalid)
+                    if (value.getGeoPoint() == null) {
+                        // create a default geo point to not break downstream applications
+                        var fallback = io.debezium.data.geometry.Geography.newBuilder()
+                                .setWkb(GeoUtils.pointToBytes(0, 0, 4326))
+                                .setSrid(4326)
+                                .build();
+                        value.setGeoPoint(fallback);
+                    }
                     var wkb = value.getGeoPoint().getWkb();
                     var point = GeoUtils.bytesToPoint(wkb);
                     var x = point.getX();
                     var y = point.getY();
+
                     return KeyValue.pair(
                             NodeKey.newBuilder().setId("i" + key.getPkEntity()).build(),
                             NodeValue.newBuilder().setId("i" + key.getPkEntity())

--- a/app-0-nodes/src/test/java/org/geovistory/toolbox/streams/nodes/processors/NodesTest.java
+++ b/app-0-nodes/src/test/java/org/geovistory/toolbox/streams/nodes/processors/NodesTest.java
@@ -280,6 +280,29 @@ class NodesTest {
         assertThat(record.getPlace()).isNotNull();
     }
 
+    @Test
+    void testNullGeoPointPlace() {
+        int id = 30;
+
+        // add place
+        var k = dev.information.place.Key.newBuilder().setPkEntity(id).build();
+        var v = dev.information.place.Value.newBuilder()
+                .setSchemaName("")
+                .setTableName("")
+                .setPkEntity(id)
+                .setGeoPoint(null)
+                .setFkClass(0)
+                .build();
+        infPlaceTopic.pipeInput(k, v);
+
+        assertThat(nodeTopic.isEmpty()).isFalse();
+        var outRecords = nodeTopic.readKeyValuesToMap();
+        assertThat(outRecords).hasSize(1);
+        var record = outRecords.get(NodeKey.newBuilder().setId("i" + id).build());
+        assertThat(record.getLabel()).isEqualTo("WGS84: 0.0°, 0.0°");
+        assertThat(record.getPlace()).isNotNull();
+    }
+
 
     @Test
     void testTimePrimitive() {

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
 ext {
-    pullRequestNumber = 101
+    pullRequestNumber = 102
     pullRequestPushCount = 0
 }


### PR DESCRIPTION
With this PR, NULL values in information.place (geo_point) will no longer break the app.
It will fallback to a geo_point of  `WGS84: 0.0°, 0.0°`