### PR TITLE
Extend entity label app to support output targets

### DIFF
--- a/app-3-entity-label3/src/main/java/org/geovistory/toolbox/streams/entity/label3/lib/Fn.java
+++ b/app-3-entity-label3/src/main/java/org/geovistory/toolbox/streams/entity/label3/lib/Fn.java
@@ -1,11 +1,10 @@
 package org.geovistory.toolbox.streams.entity.label3.lib;
 
-import org.geovistory.toolbox.streams.avro.ComLabelGroupKey;
-import org.geovistory.toolbox.streams.avro.LabelEdge;
-import org.geovistory.toolbox.streams.avro.ProjectEntityKey;
-import org.geovistory.toolbox.streams.avro.ProjectLabelGroupKey;
+import org.geovistory.toolbox.streams.avro.*;
 
 import java.time.Instant;
+
+import static org.geovistory.toolbox.streams.lib.Utils.getLanguageFromId;
 
 /**
  * Class to collect static functions
@@ -160,6 +159,88 @@ public class Fn {
         // Pad the hexadecimal string with zeros to ensure it has 8 characters
         hexString = String.format("%8s", hexString).replace(' ', '0');
         return hexString;
+    }
+
+    /**
+     * Creates a LabelEdge object based on the provided EdgeValue.
+     *
+     * @param edge The EdgeValue object to create LabelEdge from.
+     * @return A LabelEdge object with properties extracted from the EdgeValue.
+     */
+    public static LabelEdge createLabelEdge(EdgeValue edge) {
+        return LabelEdge.newBuilder()
+                .setProjectId(edge.getProjectId())
+                .setProjectPublic(visibleInProjectPublic(edge))
+                .setCommunityPublic(visibleInCommunityPublic(edge))
+                .setCommunityToolbox(visibleInCommunityToolbox(edge))
+                .setSourceClassId(edge.getSourceEntity().getFkClass())
+                .setSourceId(edge.getSourceId())
+                .setPropertyId(edge.getPropertyId())
+                .setIsOutgoing(edge.getIsOutgoing())
+                .setOrdNum(edge.getOrdNum())
+                .setModifiedAt(edge.getModifiedAt())
+                .setTargetId(edge.getTargetId())
+                .setTargetLabel(edge.getTargetNode().getLabel())
+                .setTargetLabelLanguage(extractLabelLanguage(edge.getTargetNode()))
+                .setTargetIsInProject(edge.getTargetProjectEntity() != null)
+                .setDeleted(edge.getDeleted())
+                .build();
+    }
+
+    /**
+     * Extracts the language code from the provided NodeValue's language string.
+     *
+     * @param n The NodeValue object to extract language from.
+     * @return The language code extracted from the NodeValue's language string, or "unknown" if not found.
+     */
+    private static String extractLabelLanguage(NodeValue n) {
+        if (n.getLangString() != null) {
+            var langCode = getLanguageFromId(n.getLangString().getFkLanguage());
+            if (langCode != null) return langCode;
+        }
+        return "unknown";
+    }
+
+    /**
+     * Determines if the EdgeValue is visible in the project's public context.
+     *
+     * @param s The EdgeValue object to check visibility.
+     * @return True if the EdgeValue is visible in the project's public context, false otherwise.
+     */
+    private static boolean visibleInProjectPublic(EdgeValue s) {
+        boolean isPublic = false;
+        if (s.getSourceProjectEntity() != null) {
+            isPublic = s.getSourceProjectEntity().getProjectVisibilityDataApi();
+        }
+        return isPublic;
+    }
+
+    /**
+     * Determines if the EdgeValue is visible in the community's public context.
+     *
+     * @param s The EdgeValue object to check visibility.
+     * @return True if the EdgeValue is visible in the community's public context, false otherwise.
+     */
+    private static boolean visibleInCommunityPublic(EdgeValue s) {
+        boolean isPublic = false;
+        if (s.getSourceEntity() != null) {
+            isPublic = s.getSourceEntity().getCommunityVisibilityDataApi();
+        }
+        return isPublic;
+    }
+
+    /**
+     * Determines if the EdgeValue is visible in the community's toolbox context.
+     *
+     * @param s The EdgeValue object to check visibility.
+     * @return True if the EdgeValue is visible in the community's toolbox context, false otherwise.
+     */
+    private static boolean visibleInCommunityToolbox(EdgeValue s) {
+        boolean isPublic = false;
+        if (s.getSourceEntity() != null) {
+            isPublic = s.getSourceEntity().getCommunityVisibilityToolbox();
+        }
+        return isPublic;
     }
 
 }

--- a/app-3-entity-label3/src/main/java/org/geovistory/toolbox/streams/entity/label3/lib/TopicsCreator.java
+++ b/app-3-entity-label3/src/main/java/org/geovistory/toolbox/streams/entity/label3/lib/TopicsCreator.java
@@ -51,6 +51,7 @@ public class TopicsCreator {
         topics.add(KeyValue.pair(outputTopicNames.labelEdgeBySource(), TsAdmin.CleanupConfig.COMPACT));
         topics.add(KeyValue.pair(outputTopicNames.labelEdgeByTarget(), TsAdmin.CleanupConfig.COMPACT));
         topics.add(KeyValue.pair(outputTopicNames.entityLanguageLabels(), TsAdmin.CleanupConfig.COMPACT));
+        topics.add(KeyValue.pair(outputTopicNames.labelEdgesToolboxCommunityBySource(), TsAdmin.CleanupConfig.COMPACT));
         createTopics(topics);
     }
 

--- a/app-3-entity-label3/src/main/java/org/geovistory/toolbox/streams/entity/label3/names/OutputTopicNames.java
+++ b/app-3-entity-label3/src/main/java/org/geovistory/toolbox/streams/entity/label3/names/OutputTopicNames.java
@@ -29,6 +29,10 @@ public class OutputTopicNames {
         return p("entity_language_labels");
     }
 
+    public final String labelEdgesToolboxCommunityBySource() {
+        return p("label_edges_toolbox_community_by_source");
+    }
+
     private String p(String n) {
         return Utils.prefixedOut(outPrefix, n);
     }

--- a/app-3-entity-label3/src/main/java/org/geovistory/toolbox/streams/entity/label3/names/Processors.java
+++ b/app-3-entity-label3/src/main/java/org/geovistory/toolbox/streams/entity/label3/names/Processors.java
@@ -12,5 +12,6 @@ public class Processors {
 
     public static final String JOIN_ON_NEW_EDGE = "JOIN_ON_NEW_EDGE";
     public static final String JOIN_ON_NEW_LABEL = "JOIN_ON_NEW_LABEL";
+    public static final String CREATE_COMMUNITY_TOOLBOX_EDGES = "CREATE_COMMUNITY_TOOLBOX_EDGES";
 
 }

--- a/app-3-entity-label3/src/main/java/org/geovistory/toolbox/streams/entity/label3/names/Sinks.java
+++ b/app-3-entity-label3/src/main/java/org/geovistory/toolbox/streams/entity/label3/names/Sinks.java
@@ -7,6 +7,6 @@ public class Sinks {
     public static final String LABEL_CONFIG_BY_PROJECT_CLASS_KEY = "SINK_LABEL_CONFIG_BY_PROJECT_CLASS_KEY";
     public static final String ENTITY_LABEL = "SINK_ENTITY_LABEL";
     public static final String ENTITY_LANG_LABELS = "SINK_ENTITY_LANG_LABELS";
-
+    public static final String COMMUNITY_TOOLBOX_EDGES = "SINK_COMMUNITY_TOOLBOX_EDGES";
 
 }

--- a/app-3-entity-label3/src/main/java/org/geovistory/toolbox/streams/entity/label3/processors/CreateCommunityToolboxEdges.java
+++ b/app-3-entity-label3/src/main/java/org/geovistory/toolbox/streams/entity/label3/processors/CreateCommunityToolboxEdges.java
@@ -1,43 +1,82 @@
-package org.geovistory.toolbox.streams.project.items.processors;
+package org.geovistory.toolbox.streams.entity.label3.processors;
 
 import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.state.KeyValueStore;
-import org.geovistory.toolbox.streams.avro.EdgeValue;
 import org.geovistory.toolbox.streams.avro.InProjectOrdNum;
-import org.geovistory.toolbox.streams.project.items.stores.EdgeCountStore;
-import org.geovistory.toolbox.streams.project.items.stores.EdgeOrdNumStore;
-import org.geovistory.toolbox.streams.project.items.stores.EdgeSumStore;
+import org.geovistory.toolbox.streams.avro.LabelEdge;
+import org.geovistory.toolbox.streams.entity.label3.stores.EdgeCountStore;
+import org.geovistory.toolbox.streams.entity.label3.stores.EdgeOrdNumStore;
+import org.geovistory.toolbox.streams.entity.label3.stores.EdgeSumStore;
+import org.geovistory.toolbox.streams.entity.label3.stores.EdgeVisibilityStore;
 
 
-public class CreateCommunityEdges implements Processor<String, EdgeValue, String, EdgeValue> {
+public class CreateCommunityToolboxEdges implements Processor<String, LabelEdge, String, LabelEdge> {
 
-    private ProcessorContext<String, EdgeValue> context;
+    private ProcessorContext<String, LabelEdge> context;
     private KeyValueStore<String, Integer> edgeCountStore;
     private KeyValueStore<String, Float> edgeSumStore;
     private KeyValueStore<String, InProjectOrdNum> edgeOrdNumStore;
+    private KeyValueStore<String, LabelEdge> edgeVisStore;
 
-    private final String slug;
-
-    public CreateCommunityEdges(String slug) {
-        this.slug = slug;
-    }
 
     @Override
-    public void init(ProcessorContext<String, EdgeValue> context) {
+    public void init(ProcessorContext<String, LabelEdge> context) {
+        edgeVisStore = context.getStateStore(EdgeVisibilityStore.NAME);
         edgeCountStore = context.getStateStore(EdgeCountStore.NAME);
         edgeOrdNumStore = context.getStateStore(EdgeOrdNumStore.NAME);
         edgeSumStore = context.getStateStore(EdgeSumStore.NAME);
         this.context = context;
     }
 
-    public void process(Record<String, EdgeValue> record) {
-        var newEdge = EdgeValue.newBuilder(record.value()).build();
-        var edgeCountKey = EdgeCountStore.createKey(slug, newEdge);
-        var edgeSumKey = EdgeSumStore.createKey(slug, newEdge);
+    public void process(Record<String, LabelEdge> record) {
+        if (record.value() == null) return;
 
-        var edgeBoolKey = EdgeOrdNumStore.createKey(slug, newEdge);
+        LabelEdge oldEdge = edgeVisStore.get(record.key());
+        var newEdge = record.value();
+
+        // if oldEdge null
+        if (oldEdge == null) {
+            // continue processing where visible
+            if (newEdge.getCommunityToolbox())
+                // continue process
+                count(record.withValue(newEdge));
+        } else {
+            // determine deleted flag
+            newEdge = setDeleted(oldEdge, newEdge);
+
+            // continue process
+            count(record.withValue(newEdge));
+        }
+        edgeVisStore.put(record.key(), record.value());
+
+    }
+
+    private LabelEdge setDeleted(
+            LabelEdge oldEdgeVis,
+            LabelEdge newEdgeVis
+    ) {
+        var turnedVisible = !oldEdgeVis.getCommunityToolbox() && newEdgeVis.getCommunityToolbox();
+        var turnedHidden = oldEdgeVis.getCommunityToolbox() && !newEdgeVis.getCommunityToolbox();
+        var addedToProject = oldEdgeVis.getDeleted() && !newEdgeVis.getDeleted();
+        var removedFromProject = !oldEdgeVis.getDeleted() && newEdgeVis.getDeleted();
+        var res = LabelEdge.newBuilder(newEdgeVis).build();
+        if (turnedVisible || addedToProject)
+            res.setDeleted(false);
+        else if (turnedHidden || removedFromProject) {
+            res.setDeleted(true);
+        }
+        return res;
+    }
+
+
+    public void count(Record<String, LabelEdge> record) {
+        var newEdge = LabelEdge.newBuilder(record.value()).build();
+        var edgeCountKey = EdgeCountStore.createKey(newEdge);
+        var edgeSumKey = EdgeSumStore.createKey(newEdge);
+
+        var edgeBoolKey = EdgeOrdNumStore.createKey(newEdge);
         var newIsInProject = !newEdge.getDeleted();
         var oldInProjectOrdNum = edgeOrdNumStore.get(edgeBoolKey);
         edgeOrdNumStore.put(edgeBoolKey,
@@ -62,13 +101,11 @@ public class CreateCommunityEdges implements Processor<String, EdgeValue, String
 
 
         newEdge.setProjectId(0);
-        newEdge.setSourceProjectEntity(null);
-        newEdge.setTargetProjectEntity(null);
         context.forward(record.withKey(edgeCountKey).withValue(newEdge));
     }
 
-    private void createAverageOrdNum(
-            EdgeValue newEdge,
+    private Float createAverageOrdNum(
+            LabelEdge newEdge,
             Float oldOrdNum,
             String edgeSumKey,
             boolean removed,
@@ -88,9 +125,10 @@ public class CreateCommunityEdges implements Processor<String, EdgeValue, String
                 ? sum != null ? sum / newCount : null
                 : null;
         newEdge.setOrdNum(newAvg);
+        return newAvg;
     }
 
-    private int createCount(EdgeValue newEdge, String edgeCountKey, boolean added, boolean removed) {
+    private int createCount(LabelEdge newEdge, String edgeCountKey, boolean added, boolean removed) {
         var diff = added ? 1 : removed ? -1 : 0;
 
         Integer oldCount = edgeCountStore.get(edgeCountKey);
@@ -101,9 +139,7 @@ public class CreateCommunityEdges implements Processor<String, EdgeValue, String
         if (oldCount != newCount) {
             edgeCountStore.put(edgeCountKey, newCount);
         }
-        newEdge.setProjectCount(newCount);
         return newCount;
     }
-
 
 }

--- a/app-3-entity-label3/src/main/java/org/geovistory/toolbox/streams/entity/label3/processors/CreateLabelEdges.java
+++ b/app-3-entity-label3/src/main/java/org/geovistory/toolbox/streams/entity/label3/processors/CreateLabelEdges.java
@@ -5,12 +5,11 @@ import org.apache.kafka.streams.processor.api.ProcessorContext;
 import org.apache.kafka.streams.processor.api.Record;
 import org.geovistory.toolbox.streams.avro.EdgeValue;
 import org.geovistory.toolbox.streams.avro.LabelEdge;
-import org.geovistory.toolbox.streams.avro.NodeValue;
 import org.geovistory.toolbox.streams.entity.label3.names.Sinks;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.geovistory.toolbox.streams.lib.Utils.getLanguageFromId;
+import static org.geovistory.toolbox.streams.entity.label3.lib.Fn.createLabelEdge;
 
 public class CreateLabelEdges implements Processor<String, EdgeValue, String, LabelEdge> {
     private static final Logger LOG = LoggerFactory.getLogger(CreateLabelEdges.class);
@@ -22,34 +21,16 @@ public class CreateLabelEdges implements Processor<String, EdgeValue, String, La
 
     public void process(Record<String, EdgeValue> record) {
         LOG.debug("process() called with record: {}", record);
-        var inVal = record.value();
-        var newVal = LabelEdge.newBuilder()
-                .setProjectId(inVal.getProjectId())
-                .setSourceClassId(inVal.getSourceEntity().getFkClass())
-                .setSourceId(inVal.getSourceId())
-                .setPropertyId(inVal.getPropertyId())
-                .setIsOutgoing(inVal.getIsOutgoing())
-                .setOrdNum(inVal.getOrdNum())
-                .setModifiedAt(inVal.getModifiedAt())
-                .setTargetId(inVal.getTargetId())
-                .setTargetLabel(inVal.getTargetNode().getLabel())
-                .setTargetLabelLanguage(extractLabelLanguage(inVal.getTargetNode()))
-                .setTargetIsInProject(inVal.getTargetProjectEntity() != null)
-                .setDeleted(inVal.getDeleted())
-                .build();
+
+        LabelEdge newVal = createLabelEdge(record.value());
 
         var targetIsLiteral = record.value().getTargetNode().getEntity() == null;
         if (targetIsLiteral) this.context.forward(record.withValue(newVal), Sinks.LABEL_EDGE_BY_SOURCE);
         else this.context.forward(record.withValue(newVal), Sinks.LABEL_EDGE_BY_TARGET);
     }
 
-    private static String extractLabelLanguage(NodeValue n) {
-        if (n.getLangString() != null) {
-            var langCode = getLanguageFromId(n.getLangString().getFkLanguage());
-            if (langCode != null) return langCode;
-        }
-        return "unknown";
-    }
+
+
 
 
 }

--- a/app-3-entity-label3/src/main/java/org/geovistory/toolbox/streams/entity/label3/stores/EdgeCountStore.java
+++ b/app-3-entity-label3/src/main/java/org/geovistory/toolbox/streams/entity/label3/stores/EdgeCountStore.java
@@ -1,0 +1,39 @@
+package org.geovistory.toolbox.streams.entity.label3.stores;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.geovistory.toolbox.streams.avro.LabelEdge;
+import org.geovistory.toolbox.streams.lib.processorapi.AbstractStore;
+
+/**
+ * Store to count projects of an edge and the ord num of an edge
+ * with key: slug_sourceID_propertyID_targetID_projectID
+ * where slug is public or toolbox
+ * with val: ord_num or -1
+ * -1 means, this edge has no ord_num but
+ * it is still adds to the project count
+ */
+@ApplicationScoped
+public class EdgeCountStore extends AbstractStore<String, Integer> {
+    public static final String NAME = "edge-count-store";
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public Serde<String> getKeySerde() {
+        return Serdes.String();
+    }
+
+    @Override
+    public Serde<Integer> getValueSerde() {
+        return Serdes.Integer();
+    }
+
+    public static String createKey(LabelEdge e) {
+        return String.join("_", new String[]{e.getSourceId(), e.getPropertyId() + "", e.getIsOutgoing() + "", e.getTargetId()});
+    }
+}

--- a/app-3-entity-label3/src/main/java/org/geovistory/toolbox/streams/entity/label3/stores/EdgeOrdNumStore.java
+++ b/app-3-entity-label3/src/main/java/org/geovistory/toolbox/streams/entity/label3/stores/EdgeOrdNumStore.java
@@ -1,0 +1,45 @@
+package org.geovistory.toolbox.streams.entity.label3.stores;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.geovistory.toolbox.streams.avro.InProjectOrdNum;
+import org.geovistory.toolbox.streams.avro.LabelEdge;
+import org.geovistory.toolbox.streams.entity.label3.lib.ConfiguredAvroSerde;
+import org.geovistory.toolbox.streams.lib.processorapi.AbstractStore;
+
+/**
+ * Store to keep record of edge-project relation and the ord num of an edge
+ * with key: slug_sourceID_propertyID_targetID_projectID
+ * where slug is public or toolbox
+ * with val: ord_num
+ * -1 means, this edge has no ord_num but
+ * it is still adds to the project count
+ */
+@ApplicationScoped
+public class EdgeOrdNumStore extends AbstractStore<String, InProjectOrdNum> {
+    public static final String NAME = "edge-bool-store";
+    @Inject
+    ConfiguredAvroSerde as;
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public Serde<String> getKeySerde() {
+        return Serdes.String();
+    }
+
+    @Override
+    public Serde<InProjectOrdNum> getValueSerde() {
+        return as.value();
+    }
+
+    public static String createKey(LabelEdge e) {
+        return String.join("_", new String[]{e.getSourceId(), e.getPropertyId() + "", e.getIsOutgoing() + "", e.getTargetId(), e.getProjectId() + ""});
+    }
+
+}

--- a/app-3-entity-label3/src/main/java/org/geovistory/toolbox/streams/entity/label3/stores/EdgeSumStore.java
+++ b/app-3-entity-label3/src/main/java/org/geovistory/toolbox/streams/entity/label3/stores/EdgeSumStore.java
@@ -1,0 +1,37 @@
+package org.geovistory.toolbox.streams.entity.label3.stores;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.geovistory.toolbox.streams.avro.LabelEdge;
+import org.geovistory.toolbox.streams.lib.processorapi.AbstractStore;
+
+/**
+ * Store to sum ord-num of an edges
+ * with key: slug_sourceID_propertyID_targetID_projectID
+ * where slug is public or toolbox
+ * with val: ord_num
+ */
+@ApplicationScoped
+public class EdgeSumStore extends AbstractStore<String, Float> {
+    public static final String NAME = "edge-sum-store";
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public Serde<String> getKeySerde() {
+        return Serdes.String();
+    }
+
+    @Override
+    public Serde<Float> getValueSerde() {
+        return Serdes.Float();
+    }
+
+    public static String createKey(LabelEdge e) {
+        return String.join("_", new String[]{e.getSourceId(), e.getPropertyId() + "", e.getIsOutgoing() + "", e.getTargetId()});
+    }
+}

--- a/app-3-entity-label3/src/main/java/org/geovistory/toolbox/streams/entity/label3/stores/EdgeVisibilityStore.java
+++ b/app-3-entity-label3/src/main/java/org/geovistory/toolbox/streams/entity/label3/stores/EdgeVisibilityStore.java
@@ -1,0 +1,38 @@
+package org.geovistory.toolbox.streams.entity.label3.stores;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.geovistory.toolbox.streams.avro.LabelEdge;
+import org.geovistory.toolbox.streams.entity.label3.lib.ConfiguredAvroSerde;
+import org.geovistory.toolbox.streams.lib.processorapi.AbstractStore;
+
+/**
+ * Store for statements partitioned by pk_entity
+ * with key: original
+ * with val: IprJoinValue
+ */
+@ApplicationScoped
+public class EdgeVisibilityStore extends AbstractStore<String, LabelEdge> {
+    public static final String NAME = "edge-visibility-store";
+    @Inject
+    ConfiguredAvroSerde as;
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public Serde<String> getKeySerde() {
+        return Serdes.String();
+    }
+
+    @Override
+    public Serde<LabelEdge> getValueSerde() {
+        return as.value();
+    }
+
+
+}

--- a/app-3-entity-label3/src/test/java/org/geovistory/toolbox/streams/entity/label3/CreateCommunityToolboxEdgesTest.java
+++ b/app-3-entity-label3/src/test/java/org/geovistory/toolbox/streams/entity/label3/CreateCommunityToolboxEdgesTest.java
@@ -1,0 +1,268 @@
+package org.geovistory.toolbox.streams.entity.label3;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TestOutputTopic;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.geovistory.toolbox.streams.avro.*;
+import org.geovistory.toolbox.streams.entity.label3.lib.ConfiguredAvroSerde;
+import org.geovistory.toolbox.streams.entity.label3.names.InputTopicNames;
+import org.geovistory.toolbox.streams.entity.label3.names.OutputTopicNames;
+import org.geovistory.toolbox.streams.testlib.FileRemover;
+import org.geovistory.toolbox.streams.testlib.TopologyTestDriverProfile;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.geovistory.toolbox.streams.entity.label3.names.Constants.DEFAULT_PROJECT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+@QuarkusTest
+@TestProfile(TopologyTestDriverProfile.class)
+public class CreateCommunityToolboxEdgesTest {
+
+    @Inject
+    Topology topology;
+    @Inject
+    ConfiguredAvroSerde as;
+    @Inject
+    OutputTopicNames outputTopicNames;
+    @Inject
+    InputTopicNames inputTopicNames;
+    @ConfigProperty(name = "kafka-streams.state.dir")
+    public String stateDir;
+    TopologyTestDriver testDriver;
+    TestInputTopic<ProjectClassKey, EntityLabelConfigTmstp> labelConfigByProjectClassInputTopic;
+    TestInputTopic<String, EdgeValue> projectEdgesInputTopic;
+    TestOutputTopic<String, LabelEdge> labelEdgesBySourceOutputTopic;
+    TestOutputTopic<String, LabelEdge> labelEdgesToolboxCommunityTopic;
+
+
+    @BeforeEach
+    public void setUp() {
+        testDriver = new TopologyTestDriver(topology);
+        labelConfigByProjectClassInputTopic = testDriver.createInputTopic(
+                outputTopicNames.labelConfigByProjectClass(),
+                as.kS(), as.vS()
+        );
+        projectEdgesInputTopic = testDriver.createInputTopic(
+                inputTopicNames.getProjectEdges(),
+                Serdes.String().serializer(), as.<EdgeValue>value().serializer()
+        );
+        labelEdgesBySourceOutputTopic = testDriver.createOutputTopic(
+                outputTopicNames.labelEdgeBySource(),
+                Serdes.String().deserializer(), as.<LabelEdge>value().deserializer()
+        );
+        labelEdgesToolboxCommunityTopic = testDriver.createOutputTopic(
+                outputTopicNames.labelEdgesToolboxCommunityBySource(),
+                Serdes.String().deserializer(), as.<LabelEdge>value().deserializer()
+        );
+
+    }
+
+    @AfterEach
+    public void tearDown() {
+        testDriver.close();
+        FileRemover.removeDir(this.stateDir);
+
+    }
+
+    @Test
+    public void testAddEdgesVisibility() {
+        // Publish test input
+        sendConfig(DEFAULT_PROJECT.get(), 21, 1L,
+                new EntityLabelConfigPartField[]{
+                        new EntityLabelConfigPartField(123, true, 1)
+                });
+        sendConfig(DEFAULT_PROJECT.get(), 22, 1L,
+                new EntityLabelConfigPartField[]{
+                        new EntityLabelConfigPartField(234, true, 1)
+                });
+        sendEdgeWithEntity(true, 1, 1, 1, "i1", 21, 123, true, "i2", false);
+        sendEdgeWithLiteral(true, 2, 3, 1, "i2", 22, 234, true, "i3", false);
+
+        sendEdgeWithLiteral(true, 2, 7, 2, "i2", 22, 234, true, "i3", false);
+        sendEdgeWithLiteral(true, 2, 8, 3, "i2", 22, 234, true, "i3", false);
+
+        var resBySource = labelEdgesBySourceOutputTopic.readKeyValuesToMap();
+
+        // test label edge by source
+        assertEquals(4, resBySource.size());
+        assertEquals("Foo", resBySource.get("1_i2_234_o_i3").getTargetLabel());
+        assertEquals("Foo", resBySource.get("i2_1_1_i1_123_o_i2").getTargetLabel());
+
+        var edgesToolboxCommunity = labelEdgesToolboxCommunityTopic.readKeyValuesToMap();
+
+        // test toolbox community label edges
+        assertEquals(2, edgesToolboxCommunity.size());
+        assertEquals(6F, edgesToolboxCommunity.get("i2_234_true_i3").getOrdNum());
+    }
+
+
+    @Test
+    public void testRemoveEdgesVisibility() {
+        // Publish test input
+        sendConfig(DEFAULT_PROJECT.get(), 21, 1L,
+                new EntityLabelConfigPartField[]{
+                        new EntityLabelConfigPartField(123, true, 1)
+                });
+        sendConfig(DEFAULT_PROJECT.get(), 22, 1L,
+                new EntityLabelConfigPartField[]{
+                        new EntityLabelConfigPartField(234, true, 1)
+                });
+        sendEdgeWithEntity(true, 1, 1, 1, "i1", 21, 123, true, "i2", false);
+        sendEdgeWithLiteral(true, 2, 3, 1, "i2", 22, 234, true, "i3", false);
+
+        sendEdgeWithLiteral(true, 2, 7, 2, "i2", 22, 234, true, "i3", false);
+        sendEdgeWithLiteral(true, 2, 8, 3, "i2", 22, 234, true, "i3", false);
+
+        var edgesToolboxCommunity = labelEdgesToolboxCommunityTopic.readKeyValuesToMap();
+
+        // test toolbox community label edges
+        assertEquals(2, edgesToolboxCommunity.size());
+        assertEquals(6F, edgesToolboxCommunity.get("i2_234_true_i3").getOrdNum());
+
+        // delete one project edge
+        sendEdgeWithLiteral(true, 2, 8999, 3, "i2", 22, 234, true, "i3", true);
+        edgesToolboxCommunity = labelEdgesToolboxCommunityTopic.readKeyValuesToMap();
+        assertEquals(5F, edgesToolboxCommunity.get("i2_234_true_i3").getOrdNum());
+
+        // delete all project edges
+        sendEdgeWithLiteral(true, 2, 3, 1, "i2", 22, 234, true, "i3", true);
+        sendEdgeWithLiteral(true, 2, 7, 2, "i2", 22, 234, true, "i3", true);
+        edgesToolboxCommunity = labelEdgesToolboxCommunityTopic.readKeyValuesToMap();
+        // should delete this edge
+        assertEquals(true, edgesToolboxCommunity.get("i2_234_true_i3").getDeleted());
+        // and also related edges, where entity label is removed
+        assertEquals(true, edgesToolboxCommunity.get("i1_123_true_i2").getDeleted());
+
+
+    }
+
+
+    public void sendEdgeWithEntity(boolean communityToolbox, int statementId, float ordNum, int pid, String sourceId, int sourceClassId, int propertyId, boolean isOutgoing, String targetId, boolean deleted) {
+        var v = createEdgeWithEntity(communityToolbox, statementId, ordNum, pid, sourceId, sourceClassId, propertyId, isOutgoing, targetId, deleted);
+        var k = createEdgeKey(v);
+        this.projectEdgesInputTopic.pipeInput(k, v);
+    }
+
+    public void sendEdgeWithLiteral(boolean communityToolbox, int statementId, float ordNum, int pid, String sourceId, int sourceClassId, int propertyId, boolean isOutgoing, String targetId, boolean deleted) {
+        var v = createEdgeWithLiteral(communityToolbox, statementId, ordNum, pid, sourceId, sourceClassId, propertyId, isOutgoing, targetId, deleted);
+        var k = createEdgeKey(v);
+        this.projectEdgesInputTopic.pipeInput(k, v);
+    }
+
+    public static String createEdgeKey(EdgeValue e) {
+        return createEdgeKey(e.getProjectId(), e.getSourceId(), e.getPropertyId(), e.getIsOutgoing(), e.getTargetId());
+    }
+
+    public static String createEdgeKey(int projectId, String sourceId, int propertyId, boolean isOutgoing, String targetId) {
+        return projectId + "_" + sourceId + "_" + propertyId + "_" + (isOutgoing ? "o" : "i") + "_" + targetId;
+    }
+
+    private static EdgeValue createEdgeWithEntity(boolean communityToolbox, int statementId, float ordNum, int pid, String sourceId, int sourceClassId, int propertyId, boolean isOutgoing, String targetId, boolean deleted) {
+        var e = createEdge(communityToolbox, statementId, ordNum, pid, sourceId, sourceClassId, propertyId, isOutgoing, targetId, deleted);
+        e.getTargetNode().setEntity(
+                Entity.newBuilder()
+                        .setFkClass(0)
+                        .setCommunityVisibilityWebsite(true)
+                        .setCommunityVisibilityDataApi(true)
+                        .setCommunityVisibilityToolbox(communityToolbox)
+                        .build());
+        return e;
+    }
+
+    private static EdgeValue createEdgeWithLiteral(boolean communityToolbox, int statementId, float ordNum, int pid, String sourceId, int sourceClassId, int propertyId, boolean isOutgoing, String targetId, boolean deleted) {
+        var e = createEdge(communityToolbox, statementId, ordNum, pid, sourceId, sourceClassId, propertyId, isOutgoing, targetId, deleted);
+        e.getTargetNode().setLabel("Foo");
+        e.getTargetNode().setLangString(
+                LangString.newBuilder()
+                        .setPkEntity(0)
+                        .setFkClass(0)
+                        .setString("Foo")
+                        .setFkLanguage(123)
+                        .build()
+        );
+        return e;
+    }
+
+    private static EdgeValue createEdge(boolean communityToolbox, int statementId, float ordNum, int pid, String sourceId, int sourceClassId, int propertyId, boolean isOutgoing, String targetId, boolean deleted) {
+        return EdgeValue.newBuilder()
+                .setProjectId(pid)
+                .setStatementId(statementId)
+                .setProjectCount(0)
+                .setOrdNum(ordNum)
+                .setSourceId(sourceId)
+                .setSourceEntity(Entity.newBuilder()
+                        .setFkClass(sourceClassId)
+                        .setCommunityVisibilityWebsite(false)
+                        .setCommunityVisibilityDataApi(false)
+                        .setCommunityVisibilityToolbox(communityToolbox)
+                        .build())
+                .setSourceProjectEntity(EntityValue.newBuilder()
+                        .setProjectId(0)
+                        .setEntityId("0")
+                        .setClassId(sourceClassId)
+                        .setCommunityVisibilityToolbox(communityToolbox)
+                        .setCommunityVisibilityDataApi(true)
+                        .setCommunityVisibilityWebsite(true)
+                        .setProjectVisibilityDataApi(true)
+                        .setProjectVisibilityWebsite(true)
+                        .setDeleted(false)
+                        .build())
+                .setPropertyId(propertyId)
+                .setIsOutgoing(isOutgoing)
+                .setTargetId(targetId)
+                .setTargetNode(NodeValue.newBuilder().setLabel("").setId(targetId).setClassId(0).build())
+                .setTargetProjectEntity(EntityValue.newBuilder()
+                        .setProjectId(0)
+                        .setEntityId(targetId)
+                        .setClassId(0)
+                        .setCommunityVisibilityToolbox(true)
+                        .setCommunityVisibilityDataApi(true)
+                        .setCommunityVisibilityWebsite(true)
+                        .setProjectVisibilityDataApi(true)
+                        .setProjectVisibilityWebsite(true)
+                        .setDeleted(false)
+                        .build())
+                .setModifiedAt("0")
+                .setDeleted(deleted)
+                .build();
+    }
+
+    public ProjectClassKey sendConfig(int projectId, int classId, Long timestamp, EntityLabelConfigPartField[] parts) {
+        return sendConfig(projectId, classId, timestamp, parts, false);
+    }
+
+    public ProjectClassKey sendConfig(int projectId, int classId, Long timestamp, EntityLabelConfigPartField[] parts, Boolean deleted) {
+
+        var labelparts = new ArrayList<EntityLabelConfigPart>();
+        var i = 1;
+        for (var item : parts) {
+            labelparts.add(EntityLabelConfigPart.newBuilder().setOrdNum(i).setField(item).build());
+            i++;
+        }
+
+        var k = ProjectClassKey.newBuilder().setProjectId(projectId).setClassId(classId).build();
+        var v = EntityLabelConfigTmstp.newBuilder()
+                .setProjectId(projectId)
+                .setClassId(classId)
+                .setConfig(
+                        EntityLabelConfig.newBuilder().setLabelParts(labelparts).build()
+                )
+                .setRecordTimestamp(timestamp)
+                .setDeleted(deleted)
+                .build();
+
+        labelConfigByProjectClassInputTopic.pipeInput(k, v);
+        return k;
+    }
+}

--- a/app-3-entity-label3/src/test/java/org/geovistory/toolbox/streams/entity/label3/CreateEntityLabelsTest.java
+++ b/app-3-entity-label3/src/test/java/org/geovistory/toolbox/streams/entity/label3/CreateEntityLabelsTest.java
@@ -97,7 +97,7 @@ public class CreateEntityLabelsTest {
 
     // Assure, statement order is respected also with large ord nums (assert that 10 comes after 2)
     @Test
-    public void test() {
+    public void testOrdNum() {
         // Publish test input
         sendConfig(1, 365, 1L,
                 new EntityLabelConfigPartField[]{
@@ -492,7 +492,11 @@ public class CreateEntityLabelsTest {
 
 
     public String sendLabelEdge(Integer project_id, Integer source_class_id, String source_id, Integer property_id, Boolean is_outgoing, Float ord_num, String modified_at, String target_id, String target_label, String target_label_language, Boolean target_is_in_project, Boolean deleted) {
-        return sendLabelEdge(project_id,
+        return sendLabelEdge(
+                true,
+                true,
+                true,
+                project_id,
                 source_class_id,
                 source_id,
                 property_id,
@@ -507,7 +511,30 @@ public class CreateEntityLabelsTest {
     }
 
     public String sendLabelEdge(Integer project_id, Integer source_class_id, String source_id, Integer property_id, Boolean is_outgoing, Float ord_num, String modified_at, String target_id, String target_label, String target_label_language, Boolean target_is_in_project, Boolean deleted, Boolean targetIsLiteral) {
-        var v = new LabelEdge(project_id,
+        return sendLabelEdge(
+                true,
+                true,
+                true,
+                project_id,
+                source_class_id,
+                source_id,
+                property_id,
+                is_outgoing,
+                ord_num,
+                modified_at,
+                target_id,
+                target_label,
+                target_label_language,
+                target_is_in_project,
+                deleted, targetIsLiteral);
+    }
+
+    public String sendLabelEdge(Boolean project_public, Boolean community_public, Boolean community_toolbox, Integer project_id, Integer source_class_id, String source_id, Integer property_id, Boolean is_outgoing, Float ord_num, String modified_at, String target_id, String target_label, String target_label_language, Boolean target_is_in_project, Boolean deleted, Boolean targetIsLiteral) {
+        var v = new LabelEdge(
+                project_public,
+                community_public,
+                community_toolbox,
+                project_id,
                 source_class_id,
                 source_id,
                 property_id,

--- a/app-3-entity-label3/src/test/java/org/geovistory/toolbox/streams/entity/label3/JoinTest.java
+++ b/app-3-entity-label3/src/test/java/org/geovistory/toolbox/streams/entity/label3/JoinTest.java
@@ -205,6 +205,9 @@ public class JoinTest {
 
     public String sendEdge(Integer project_id, Integer source_class_id, String source_id, Integer property_id, Boolean is_outgoing, Float ord_num, String modified_at, String target_id, String target_label, String target_label_language, Boolean target_is_in_project, Boolean deleted) {
         var v = LabelEdge.newBuilder()
+                .setCommunityToolbox(true)
+                .setCommunityPublic(true)
+                .setProjectPublic(true)
                 .setProjectId(project_id)
                 .setSourceClassId(source_class_id)
                 .setSourceId(source_id)

--- a/app-3-entity-label3/src/test/java/org/geovistory/toolbox/streams/entity/label3/LabelEdgeBySourceStoreTest.java
+++ b/app-3-entity-label3/src/test/java/org/geovistory/toolbox/streams/entity/label3/LabelEdgeBySourceStoreTest.java
@@ -74,6 +74,9 @@ public class LabelEdgeBySourceStoreTest {
     public void sendLabelEdge() {
         String k = "k";
         var v = LabelEdge.newBuilder()
+                .setCommunityToolbox(true)
+                .setCommunityPublic(true)
+                .setProjectPublic(true)
                 .setProjectId(0)
                 .setSourceClassId(0)
                 .setSourceId("0")

--- a/app-3-entity-label3/topology.md
+++ b/app-3-entity-label3/topology.md
@@ -11,10 +11,15 @@ CREATE_ENTITY_LABELS(CREATE_ENTITY_LABELS) --> label-config-tmstp-store[(label-<
 ts_p_items_project_edges[ts_p_items_project_edges] --> SOURCE_EDGE(SOURCE_EDGE)
 ts_3el4_entity_labels[ts_3el4_entity_labels] --> SOURCE_LABEL(SOURCE_LABEL)
 ts_3el4_label_edge_by_target[ts_3el4_label_edge_by_target] --> SOURCE_LABEL_EDGE_BY_TARGET(SOURCE_LABEL_EDGE_BY_TARGET)
+CREATE_COMMUNITY_TOOLBOX_EDGES(CREATE_COMMUNITY_TOOLBOX_EDGES) --> edge-sum-store[(edge-<br>sum-<br>store)]
+CREATE_COMMUNITY_TOOLBOX_EDGES(CREATE_COMMUNITY_TOOLBOX_EDGES) --> edge-count-store[(edge-<br>count-<br>store)]
+CREATE_COMMUNITY_TOOLBOX_EDGES(CREATE_COMMUNITY_TOOLBOX_EDGES) --> edge-bool-store[(edge-<br>bool-<br>store)]
+CREATE_COMMUNITY_TOOLBOX_EDGES(CREATE_COMMUNITY_TOOLBOX_EDGES) --> edge-visibility-store[(edge-<br>visibility-<br>store)]
 label-edge-by-target-store[(label-<br>edge-<br>by-<br>target-<br>store)] --> JOIN_ON_NEW_EDGE(JOIN_ON_NEW_EDGE)
 entity-label-store[(entity-<br>label-<br>store)] --> JOIN_ON_NEW_EDGE(JOIN_ON_NEW_EDGE)
 label-edge-by-target-store[(label-<br>edge-<br>by-<br>target-<br>store)] --> JOIN_ON_NEW_LABEL(JOIN_ON_NEW_LABEL)
 entity-label-store[(entity-<br>label-<br>store)] --> JOIN_ON_NEW_LABEL(JOIN_ON_NEW_LABEL)
+SINK_COMMUNITY_TOOLBOX_EDGES(SINK_COMMUNITY_TOOLBOX_EDGES) --> ts_3el4_label_edges_toolbox_community_by_source[ts_3el4_label_edges_toolbox_community_by_source]
 SINK_ENTITY_LABEL(SINK_ENTITY_LABEL) --> ts_3el4_entity_labels[ts_3el4_entity_labels]
 SINK_ENTITY_LANG_LABELS(SINK_ENTITY_LANG_LABELS) --> ts_3el4_entity_language_labels[ts_3el4_entity_language_labels]
 SINK_LABEL_EDGE_BY_SOURCE(SINK_LABEL_EDGE_BY_SOURCE) --> ts_3el4_label_edge_by_source[ts_3el4_label_edge_by_source]
@@ -24,6 +29,7 @@ SINK_LABEL_CONFIG_BY_PROJECT_CLASS_KEY(SINK_LABEL_CONFIG_BY_PROJECT_CLASS_KEY) -
 ts_3el4_label_config_by_project_class_key[ts_3el4_label_config_by_project_class_key] --> SOURCE_LABEL_CONFIG_BY_CLASS_KEY(SOURCE_LABEL_CONFIG_BY_CLASS_KEY)
 UPDATE_GLOBAL_STORE_LABEL_CONFIG(UPDATE_GLOBAL_STORE_LABEL_CONFIG) --> global-label-config-store[(global-<br>label-<br>config-<br>store)]
 subgraph Sub-Topology: 0
+SOURCE_LABEL_EDGE_BY_SOURCE(SOURCE_LABEL_EDGE_BY_SOURCE) --> CREATE_COMMUNITY_TOOLBOX_EDGES(CREATE_COMMUNITY_TOOLBOX_EDGES)
 SOURCE_LABEL_EDGE_BY_SOURCE(SOURCE_LABEL_EDGE_BY_SOURCE) --> UPDATE_LABEL_EDGES_BY_SOURCE_STORE(UPDATE_LABEL_EDGES_BY_SOURCE_STORE)
 UPDATE_LABEL_EDGES_BY_SOURCE_STORE(UPDATE_LABEL_EDGES_BY_SOURCE_STORE) --> CREATE_ENTITY_LABELS(CREATE_ENTITY_LABELS)
 CREATE_ENTITY_LABELS(CREATE_ENTITY_LABELS) --> RE_KEY_ENTITY_LABELS(RE_KEY_ENTITY_LABELS)
@@ -33,6 +39,7 @@ PROCESSOR_CREATE_LABEL_EDGES(PROCESSOR_CREATE_LABEL_EDGES) --> SINK_LABEL_EDGE_B
 PROCESSOR_CREATE_LABEL_EDGES(PROCESSOR_CREATE_LABEL_EDGES) --> SINK_LABEL_EDGE_BY_TARGET(SINK_LABEL_EDGE_BY_TARGET)
 SOURCE_LABEL(SOURCE_LABEL) --> JOIN_ON_NEW_LABEL(JOIN_ON_NEW_LABEL)
 SOURCE_LABEL_EDGE_BY_TARGET(SOURCE_LABEL_EDGE_BY_TARGET) --> JOIN_ON_NEW_EDGE(JOIN_ON_NEW_EDGE)
+CREATE_COMMUNITY_TOOLBOX_EDGES(CREATE_COMMUNITY_TOOLBOX_EDGES) --> SINK_COMMUNITY_TOOLBOX_EDGES(SINK_COMMUNITY_TOOLBOX_EDGES)
 JOIN_ON_NEW_EDGE(JOIN_ON_NEW_EDGE) --> SINK_LABEL_EDGE_BY_SOURCE(SINK_LABEL_EDGE_BY_SOURCE)
 JOIN_ON_NEW_LABEL(JOIN_ON_NEW_LABEL) --> SINK_LABEL_EDGE_BY_SOURCE(SINK_LABEL_EDGE_BY_SOURCE)
 RE_KEY_ENTITY_LABELS(RE_KEY_ENTITY_LABELS) --> SINK_ENTITY_LABEL(SINK_ENTITY_LABEL)
@@ -51,6 +58,7 @@ ts_3el4_entity_labels
 ts_3el4_label_edge_by_target
 ts.projects.entity_label_config
 ts_3el4_label_config_by_project_class_key
+ts_3el4_label_edges_toolbox_community_by_source
 ts_3el4_entity_labels
 ts_3el4_entity_language_labels
 ts_3el4_label_edge_by_source
@@ -63,6 +71,10 @@ com-label-rank-store
 com-label-lang-rank-store
 label-edge-by-source-store
 label-config-tmstp-store
+edge-sum-store
+edge-count-store
+edge-bool-store
+edge-visibility-store
 label-edge-by-target-store
 entity-label-store
 label-edge-by-target-store

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
 ext {
-    pullRequestNumber = 141
-    pullRequestPushCount = 2
+    pullRequestNumber = 142
+    pullRequestPushCount = 0
 }

--- a/lib/src/main/avro/custom/el3/LabelEdge.avsc
+++ b/lib/src/main/avro/custom/el3/LabelEdge.avsc
@@ -5,6 +5,18 @@
   "doc": "An edge with the target label.",
   "fields": [
     {
+      "name": "project_public",
+      "type": "boolean"
+    },
+    {
+      "name": "community_public",
+      "type": "boolean"
+    },
+    {
+      "name": "community_toolbox",
+      "type": "boolean"
+    },
+    {
       "name": "project_id",
       "type": "int",
       "default": 0


### PR DESCRIPTION
This PR adds
- a topic with label-edges for the toolbox-community (to be used by fulltext app)
- 3 topics with entity labels for toolbox-community, public-community and public-project (to be used by rdf serializers)